### PR TITLE
[alarms] Fix Qt5 version of AlarmHandlerInterface::activeDialogs()

### DIFF
--- a/src/alarmhandlerinterface.cpp
+++ b/src/alarmhandlerinterface.cpp
@@ -34,8 +34,12 @@
 #include "alarmdialogobject.h"
 #include <QTimer>
 
-AlarmHandlerInterface::AlarmHandlerInterface(QDeclarativeItem *parent)
-    : QDeclarativeItem(parent),
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+Q_DECLARE_METATYPE(QList<QObject *>)
+#endif
+
+AlarmHandlerInterface::AlarmHandlerInterface(QObject *parent)
+    : QObject(parent),
       adaptor(new VolandAdaptor(this)),
       signalWrapper(new VolandSignalWrapper(this)),
       m_dialogOnScreen(false)
@@ -129,9 +133,9 @@ void AlarmHandlerInterface::dialogClosed(QObject *obj)
     emit activeDialogsChanged();
 }
 
-QObjectList AlarmHandlerInterface::activeDialogs() const
+QList<QObject *> AlarmHandlerInterface::activeDialogs() const
 {
-    QObjectList re;
+    QList<QObject *> re;
     re.reserve(dialogs.size());
     foreach (AlarmDialogObject *dialog, dialogs)
         re.append(dialog);

--- a/src/alarmhandlerinterface.h
+++ b/src/alarmhandlerinterface.h
@@ -35,14 +35,10 @@
 
 #include <QtGlobal>
 #include <QDBusAbstractAdaptor>
-
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 # include <timed-voland-qt5/interface>
-# include <QQuickItem>
-# define QDeclarativeItem QQuickItem
 #else
 # include <timed-voland/interface>
-# include <QDeclarativeItem>
 #endif
 
 class VolandAdaptor;
@@ -58,20 +54,21 @@ namespace Maemo {
     }
 }
 
-class AlarmHandlerInterface : public QDeclarativeItem
+class AlarmHandlerInterface : public QObject
 {
     Q_OBJECT
 
 public:
-    AlarmHandlerInterface(QDeclarativeItem *parent = 0);
+    AlarmHandlerInterface(QObject *parent = 0);
+
 
     /*!
-     *  \qmlproperty QObjectList AlarmHandler::activeDialogs
+     *  \qmlproperty QList<Object *> AlarmHandler::activeDialogs
      *
      *  A list of \a AlarmDialogObject instances for active alarm dialogs.
      */
-    Q_PROPERTY(QObjectList activeDialogs READ activeDialogs NOTIFY activeDialogsChanged)
-    QObjectList activeDialogs() const;
+    Q_PROPERTY(QList<QObject *>  activeDialogs READ activeDialogs NOTIFY activeDialogsChanged)
+    QList<QObject *> activeDialogs() const;
 
     /*!
      *  \qmlproperty bool AlarmHandler::dialogOnScreen


### PR DESCRIPTION
Exposing QObjectList to QML in Qt5 is not supported, use QList<Qobject *> instead (as suggested by rburchell, thanks!).

In addition, use QObject as AlarmHandlerInterface base class, no need for QDeclarativeItem/QQuickItem as the there's no visual stuff in AlarmHandlerInterface.
