### PR TITLE
[alarms] Fix sorting of alarms

### DIFF
--- a/src/alarmsbackendmodel_p.cpp
+++ b/src/alarmsbackendmodel_p.cpp
@@ -168,8 +168,16 @@ void AlarmsBackendModelPriv::alarmUpdated(AlarmObject *alarm)
 {
     int currentRow = alarms.indexOf(alarm);
 
+    // qLowerBounds expects that the list is sorted, we do not know if that is the case after
+    // the alarm has changed. Remove it temporarily from the list while calculating new row.
+    if (currentRow >= 0)
+        alarms.removeAt(currentRow);
+
     QList<AlarmObject*>::iterator it = qLowerBound(alarms.begin(), alarms.end(), alarm, alarmSort);
     int newRow = it - alarms.begin();
+
+    if (currentRow >= 0)
+        alarms.insert(currentRow, alarm);
 
     if (currentRow < 0) {
         alarm->setParent(this);


### PR DESCRIPTION
Do not perform qLowerBounds on the list of alarms that is not ordered. This caused the calculated new index of the alarm to be off and even out of bounds sometimes, which caused a seg fault.
