### PR TITLE
[alarms] Support for read-only calendar alarms, add type property

### DIFF
--- a/src/alarmobject.cpp
+++ b/src/alarmobject.cpp
@@ -81,6 +81,12 @@ AlarmObject::AlarmObject(const QMap<QString,QString> &data, QObject *parent)
         } else if (it.key() == "triggerTime") {
             m_countdown = true;
             m_triggerTime = it.value().toUInt();
+        } else if (it.key() == "startDate") {
+            m_startDate = QDateTime::fromString(it.value(), Qt::ISODate);
+        } else if (it.key() == "endDate") {
+            m_endDate = QDateTime::fromString(it.value(), Qt::ISODate);
+        } else if (it.key() == "uid") {
+            m_uid = it.value();
         }
     }
 
@@ -158,6 +164,43 @@ void AlarmObject::setCountdown(bool countdown)
 
     m_countdown = countdown;
     emit countdownChanged();
+    emit typeChanged();
+}
+
+int AlarmObject::type() const
+{
+    if (m_startDate.isValid() && m_endDate.isValid())
+        return Calendar;
+    else if (m_countdown)
+        return Countdown;
+    else
+        return Clock;
+}
+
+QDateTime AlarmObject::startDate() const
+{
+    return m_startDate;
+}
+
+QDateTime AlarmObject::endDate() const
+{
+    return m_endDate;
+}
+
+bool AlarmObject::allDay() const
+{
+    if (!m_startDate.isValid() || !m_endDate.isValid())
+        return false;
+
+    QTime start = m_startDate.time();
+    QTime end = m_endDate.time();
+
+    return start.minute() == 0 && start.hour() == 0 && start == end;
+}
+
+QString AlarmObject::calendarUid() const
+{
+    return m_uid;
 }
 
 void AlarmObject::reset()

--- a/src/alarmobject.h
+++ b/src/alarmobject.h
@@ -48,6 +48,9 @@ public:
     AlarmObject(QObject *parent = 0);
     AlarmObject(const QMap<QString,QString> &data, QObject *parent = 0);
 
+    enum Type { Calendar, Clock, Countdown };
+    Q_ENUMS(Type)
+
     /*!
      *  \qmlproperty string Alarm::title
      *
@@ -171,6 +174,58 @@ public:
     int getElapsed() const { return m_elapsed; }
 
     /*!
+      * \qmlproperty string Alarm::type
+      *
+      * Indicates the type of the alarm, possible values are Alarm::Clock, Alarm::Countdown,
+      * and Alarm::Calendar. Calendar alarms are read only, they cannot be added through this
+      * plugin, only read.
+      *
+      * \sa countdown
+      */
+    Q_PROPERTY(int type READ type NOTIFY typeChanged)
+    int type() const;
+
+    /*!
+      * \qmlproperty string Alarm::startDate
+      *
+      * The start date of an calendar event. Only valid for calendar alarms.
+      *
+      * \sa type
+      */
+    Q_PROPERTY(QDateTime startDate READ startDate CONSTANT)
+    QDateTime startDate() const;
+
+    /*!
+      * \qmlproperty string Alarm::endDate
+      *
+      * The end date of an calendar event. Only valid for calendar alarms.
+      *
+      * \sa type
+      */
+    Q_PROPERTY(QDateTime endDate READ endDate CONSTANT)
+    QDateTime endDate() const;
+
+    /*!
+      * \qmlproperty string Alarm::allDay
+      *
+      * Indicates if this alarm represents an all day event. Only valid for calendar alarms.
+      *
+      * \sa type
+      */
+    Q_PROPERTY(bool allDay READ allDay CONSTANT)
+    bool allDay() const;
+
+    /*!
+      * \qmlproperty string Alarm::calendarUid
+      *
+      * An unique identifier of a calendar event. Only valid for calendar alarms.
+      *
+      * \sa type
+      */
+    Q_PROPERTY(QString calendarUid READ calendarUid CONSTANT)
+    QString calendarUid() const;
+
+    /*!
      *  \qmlmethod void Alarm::reset()
      *
      *  If the alarm is a countdown alarm, then sets \a elapsed and \a triggerTime to 0.
@@ -208,6 +263,7 @@ signals:
     void countdownChanged();
     void triggerTimeChanged();
     void elapsedChanged();
+    void typeChanged();
 
     /*!
      *  \qmlsignal Alarm::updated()
@@ -248,6 +304,8 @@ protected:
     bool m_countdown;
     uint m_triggerTime;
     uint m_elapsed;
+    QDateTime m_startDate, m_endDate;
+    QString m_uid;
 
     // Timed
     unsigned m_cookie;


### PR DESCRIPTION
If the Maemo::Timed::Event event contains the attributes startDate and endDate which are valid ISO 8601 extended format dates, then interpret the event as a calendar alarm. Calendar alarms are read only, they cannot be added through this plugin, only read. 

The startDate QML property indicates when the event starts, endDate indicates when the event ends.

The allDay QML property simply indicates whether the startDate and endDate times are both 00:00, in which case the calendar alarm is interpreted as an all day event.

The calendar specific properties are read from the Maemo::Timed::Event attributes which have the same names as the QML properties described above.

The type QML property is one of the enumeration values Alarm::Calendar, Alarm::Countdown, and Alarm::Clock,
the property indicates the type of the alarm.
