### PR TITLE
[alarms] Parse calendar event start and end times correctly

### DIFF
--- a/src/alarmobject.cpp
+++ b/src/alarmobject.cpp
@@ -82,9 +82,9 @@ AlarmObject::AlarmObject(const QMap<QString,QString> &data, QObject *parent)
             m_countdown = true;
             m_triggerTime = it.value().toUInt();
         } else if (it.key() == "startDate") {
-            m_startDate = QDateTime::fromString(it.value(), Qt::ISODate);
+            m_startDate = parseIsoDate(it.value());
         } else if (it.key() == "endDate") {
-            m_endDate = QDateTime::fromString(it.value(), Qt::ISODate);
+            m_endDate = parseIsoDate(it.value());
         } else if (it.key() == "uid") {
             m_uid = it.value();
         } else if (it.key() == "timeoutSnoozeCounter") {
@@ -360,3 +360,9 @@ void AlarmObject::deleteReply(QDBusPendingCallWatcher *w)
         qWarning() << "org.nemomobile.alarms: Cannot delete alarm from timed:" << reply.error();
 }
 
+QDateTime AlarmObject::parseIsoDate(const QString &isoDate)
+{
+    QDateTime tmp = QDateTime::fromString(isoDate, Qt::ISODate);
+    tmp.setTimeSpec(Qt::OffsetFromUTC); // Needed to not interpret TZ +00:00 as localtime
+    return tmp.toUTC().toLocalTime(); // toUtc() called because of QTBUG-29666
+}

--- a/src/alarmobject.h
+++ b/src/alarmobject.h
@@ -337,6 +337,9 @@ signals:
      */
     void deleted();
 
+private:
+    QDateTime parseIsoDate(const QString &isoDate);
+
 private slots:
     void saveReply(QDBusPendingCallWatcher *w);
     void deleteReply(QDBusPendingCallWatcher *w);


### PR DESCRIPTION
QDateTime interprets ISO 8601 time zone +00:00 as localtime unless the timespec is Qt::OffsetFromUTC.

The bug QTBUG-29666 causes QDateTime::localTime() to fail, workaround is to use QDateTime::toUTC().
