### PR TITLE
[alarms] Fix calendar event start and end times for Qt 5.2

### DIFF
--- a/src/alarmobject.cpp
+++ b/src/alarmobject.cpp
@@ -82,9 +82,9 @@ AlarmObject::AlarmObject(const QMap<QString,QString> &data, QObject *parent)
             m_countdown = true;
             m_triggerTime = it.value().toUInt();
         } else if (it.key() == "startDate") {
-            m_startDate = parseIsoDate(it.value());
+            m_startDate = QDateTime::fromString(it.value(), Qt::ISODate);
         } else if (it.key() == "endDate") {
-            m_endDate = parseIsoDate(it.value());
+            m_endDate = QDateTime::fromString(it.value(), Qt::ISODate);
         } else if (it.key() == "uid") {
             m_uid = it.value();
         } else if (it.key() == "timeoutSnoozeCounter") {
@@ -360,9 +360,3 @@ void AlarmObject::deleteReply(QDBusPendingCallWatcher *w)
         qWarning() << "org.nemomobile.alarms: Cannot delete alarm from timed:" << reply.error();
 }
 
-QDateTime AlarmObject::parseIsoDate(const QString &isoDate)
-{
-    QDateTime tmp = QDateTime::fromString(isoDate, Qt::ISODate);
-    tmp.setTimeSpec(Qt::OffsetFromUTC); // Needed to not interpret TZ +00:00 as localtime
-    return tmp.toUTC().toLocalTime(); // toUtc() called because of QTBUG-29666
-}

--- a/src/alarmobject.h
+++ b/src/alarmobject.h
@@ -337,9 +337,6 @@ signals:
      */
     void deleted();
 
-private:
-    QDateTime parseIsoDate(const QString &isoDate);
-
 private slots:
     void saveReply(QDBusPendingCallWatcher *w);
     void deleteReply(QDBusPendingCallWatcher *w);


### PR DESCRIPTION
The workaround introduced for Qt 5.1 didn't work properly for Qt 5.2.
Remove it now.

This reverts commit cab4fbc8368b7ab496fba90e1d6d98dcc6d4fbf3.
